### PR TITLE
Put state on "g" instead of _request_ctx_stack

### DIFF
--- a/propelauth_flask/__init__.py
+++ b/propelauth_flask/__init__.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 
-from flask import _request_ctx_stack
+from flask import g
 from propelauth_py import TokenVerificationMetadata, init_base_auth
 from werkzeug.local import LocalProxy
 
@@ -15,12 +15,12 @@ from propelauth_flask.auth_decorator import (
 
 """Returns the current user. Must be used with one of require_user, optional_user, or require_org_member"""
 current_user = LocalProxy(
-    lambda: getattr(_request_ctx_stack.top, "propelauth_current_user", None)
+    lambda: getattr(g, "propelauth_current_user", None)
 )
 
 """Returns the current org. Must be used with require_org_member"""
 current_org = LocalProxy(
-    lambda: getattr(_request_ctx_stack.top, "propelauth_current_org", None)
+    lambda: getattr(g, "propelauth_current_org", None)
 )
 
 Auth = namedtuple(

--- a/propelauth_flask/auth_decorator.py
+++ b/propelauth_flask/auth_decorator.py
@@ -1,6 +1,6 @@
 import functools
 
-from flask import _request_ctx_stack, request, abort, Response
+from flask import g, request, abort, Response
 from propelauth_py import UnauthorizedException
 from propelauth_py.errors import ForbiddenException
 
@@ -15,10 +15,10 @@ def _get_user_credential_decorator(validate_access_token_and_get_user, require_u
                 authorization_header = request.headers.get("Authorization")
                 user = validate_access_token_and_get_user(authorization_header)
 
-                _request_ctx_stack.top.propelauth_current_user = LoggedInUser(user)
+                g.propelauth_current_user = LoggedInUser(user)
 
             except UnauthorizedException as e:
-                _request_ctx_stack.top.propelauth_current_user = LoggedOutUser()
+                g.propelauth_current_user = LoggedOutUser()
                 _return_401_if_user_required(e, require_user, debug_mode)
 
             return func(*args, **kwargs)
@@ -38,8 +38,8 @@ def _get_require_org_decorator(validate_access_token_and_get_user_with_org, debu
                     required_org_id = req_to_org_id(request)
                     user_and_org = validate_access_token_and_get_user_with_org(authorization_header, required_org_id)
 
-                    _request_ctx_stack.top.propelauth_current_user = user_and_org.user
-                    _request_ctx_stack.top.propelauth_current_org = user_and_org.org_member_info
+                    g.propelauth_current_user = user_and_org.user
+                    g.propelauth_current_org = user_and_org.org_member_info
 
                 except UnauthorizedException as e:
                     _return_401_if_user_required(e, True, debug_mode)
@@ -68,8 +68,8 @@ def _require_org_member_with_minimum_role_decorator(validate_access_token_and_ge
                     user_and_org = validate_access_token_and_get_user_with_org_by_minimum_role(
                         authorization_header, required_org_id, minimum_required_role)
 
-                    _request_ctx_stack.top.propelauth_current_user = user_and_org.user
-                    _request_ctx_stack.top.propelauth_current_org = user_and_org.org_member_info
+                    g.propelauth_current_user = user_and_org.user
+                    g.propelauth_current_org = user_and_org.org_member_info
 
                 except UnauthorizedException as e:
                     _return_401_if_user_required(e, True, debug_mode)
@@ -98,8 +98,8 @@ def _require_org_member_with_exact_role_decorator(validate_access_token_and_get_
                     user_and_org = validate_access_token_and_get_user_with_org_by_exact_role(
                         authorization_header, required_org_id, role)
 
-                    _request_ctx_stack.top.propelauth_current_user = user_and_org.user
-                    _request_ctx_stack.top.propelauth_current_org = user_and_org.org_member_info
+                    g.propelauth_current_user = user_and_org.user
+                    g.propelauth_current_org = user_and_org.org_member_info
 
                 except UnauthorizedException as e:
                     _return_401_if_user_required(e, True, debug_mode)
@@ -128,8 +128,8 @@ def _require_org_member_with_permission_decorator(validate_access_token_and_get_
                     user_and_org = validate_access_token_and_get_user_with_org_by_permission(
                         authorization_header, required_org_id, permission)
 
-                    _request_ctx_stack.top.propelauth_current_user = user_and_org.user
-                    _request_ctx_stack.top.propelauth_current_org = user_and_org.org_member_info
+                    g.propelauth_current_user = user_and_org.user
+                    g.propelauth_current_org = user_and_org.org_member_info
 
                 except UnauthorizedException as e:
                     _return_401_if_user_required(e, True, debug_mode)
@@ -158,8 +158,8 @@ def _require_org_member_with_all_permissions_decorator(validate_access_token_and
                     user_and_org = validate_access_token_and_get_user_with_org_by_all_permissions(
                         authorization_header, required_org_id, permissions)
 
-                    _request_ctx_stack.top.propelauth_current_user = user_and_org.user
-                    _request_ctx_stack.top.propelauth_current_org = user_and_org.org_member_info
+                    g.propelauth_current_user = user_and_org.user
+                    g.propelauth_current_org = user_and_org.org_member_info
 
                 except UnauthorizedException as e:
                     _return_401_if_user_required(e, True, debug_mode)


### PR DESCRIPTION
Tests current emit this warning:

`/var/lang/lib/python3.9/site-packages/propelauth_flask/__init__.py:18: DeprecationWarning: '_request_ctx_stack' is deprecated and will be removed in Flask 2.4. Use 'g' to store data, or 'request_ctx' to access the current context.`

This change does as suggested and store the propelauth attributes directly on "g" instead.  Warning then goes away, tests all still pass.